### PR TITLE
Update to Farkle 6.4.0 and .NET 6.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "farkle.tools": {
-      "version": "6.3.2",
+      "version": "6.4.0",
       "commands": [
         "farkle"
       ]

--- a/KuiLang/KuiLang.csproj
+++ b/KuiLang/KuiLang.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<FarkleGenerateHtml>true</FarkleGenerateHtml>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Farkle" Version="6.3.2" />
-		<PackageReference Include="Farkle.Tools.MSBuild" Version="6.3.2" PrivateAssets="all" />
+		<PackageReference Include="Farkle" Version="6.4.0" />
+		<PackageReference Include="Farkle.Tools.MSBuild" Version="6.4.0" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/Tests/KuiLang.Tests/KuiLang.Tests.csproj
+++ b/Tests/KuiLang.Tests/KuiLang.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Farkle 6.4.0 was released minutes ago. It adds support for .NET 6 and fixes a couple of bugs.