### PR TITLE
Fix a `NullReferenceException`.

### DIFF
--- a/Tests/KuiLang.Tests/KuiLang.Tests.csproj
+++ b/Tests/KuiLang.Tests/KuiLang.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-	  <PackageReference Include="Farkle.Tools.MSBuild" Version="6.3.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `KuiLang` class declares some designtime Farkles for parts of the grammar. In one case while setting the productions for the `Statement` nonterminal, we use the `MethodDeclarationDesigntime` static field before initializing it, instead of the `methodDeclaration` local variable. We pass a `null` to Farkle, it does not get checked, and fails mysteriously when building the grammar.

This PR moves the initialization of these static fields in the bottom, and stops using them while constructing the grammar, prefering the locals. I also removed `Farkle.Tools.MSBuild` from the test project; it is not needed, only projects that declare a precompilable designtime Farkle need it.

It remains a mystery why Roslyn did not warn about `MethodDeclarationDesigntime` being null; perhaps it has to do something with `Finish` on designtime Farkles being an extension method.

After fixing this there are still some errors, including conflicts in the grammar.